### PR TITLE
[Rust] Removed extra method

### DIFF
--- a/Rust/main.rs
+++ b/Rust/main.rs
@@ -27,7 +27,7 @@ mod rot13 {
 
     impl Rot13 for String {
         fn rot13(&self) -> String {
-            return self.chars().map(|ch: char| {
+            self.chars().map(|ch: char| {
                 let indexed = transform_to_index(ch);
     
                 if indexed.1 <= 26 {
@@ -35,20 +35,16 @@ mod rot13 {
                 } else {
                     indexed.1 as char
                 }
-            }).collect::<String>();
+            }).collect::<String>()
         }
 
-
+        
+        /// Encoding already encoded string by rot13 algorithm second time
+        /// returns the initial string due to number of letters in alphabet
+        /// (26 letters in total, and shifting by 13 will make pairs like
+        /// ('a', 'n') or ('n', 'a'))
         fn unrot13(&self) -> String {
-            return self.chars().map(|ch: char| {
-                let indexed = transform_to_index(ch);
-    
-                if indexed.1 <= 26 {
-                    transform_to_ascii(indexed.0, if indexed.1 < 13 { indexed.1 + 13 } else { indexed.1 - 13 })
-                } else {
-                    indexed.1 as char
-                }
-            }).collect::<String>();
+            self.rot13()
         }
     }
 }


### PR DESCRIPTION
Well, encoding the rot13-encoded string will return a initial string.
Thus `.unrot13()` calls `.rot13()`.