### PR TITLE
Adding Emacs Lisp implementation

### DIFF
--- a/Emacs Lisp/main.el
+++ b/Emacs Lisp/main.el
@@ -3,7 +3,7 @@
 ;;; Code:
 (defun encode-rot13 (text) 
   "Cipher text with ROT13." 
-  (interactive "sEnter string to encode:") 
+  (interactive "sEnter string to encode: ") 
   (message (concat "Encoded string:\n" (rot13-string text))))
 
 ;;; main.el ends here

--- a/Emacs Lisp/main.el
+++ b/Emacs Lisp/main.el
@@ -1,0 +1,9 @@
+;;; main.el --- ROT13
+
+;;; Code:
+(defun encode-rot13 (text) 
+  "Cipher text with ROT13." 
+  (interactive "sEnter string to encode:") 
+  (message (concat "Encoded string:\n" (rot13-string text))))
+
+;;; main.el ends here


### PR DESCRIPTION
As it turns out, Emacs already has an implementation of ROT13, so I just made a wrapper function